### PR TITLE
Make copyright year dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         </address>
     </aside>
     <footer>
-        <p>(c) 2025 juliocebrito All rights reserved.</p>
+        <p>(c) <span id="current-year">2025</span> juliocebrito All rights reserved.</p>
     </footer>
     <script src="scripts.js"></script>
   </body>

--- a/scripts.js
+++ b/scripts.js
@@ -1,1 +1,7 @@
-// alert('Hello World')
+window.onload = function() {
+  const currentYear = new Date().getFullYear();
+  const yearElement = document.getElementById("current-year");
+  if (yearElement) {
+    yearElement.textContent = currentYear;
+  }
+};


### PR DESCRIPTION
The copyright year in the footer was previously hardcoded. This change updates it to be dynamically set to the current year using JavaScript.

- Added a span with id `current-year` around the year in `index.html`.
- Added JavaScript in `scripts.js` to update the content of this span to the current year when the page loads.