### PR TITLE
Style: Apply Terminal Art design to section titles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,22 @@ main section > h1 {
     /* Color inherited */
 }
 
+section#past h1,
+section#present h1,
+section#future h1 {
+    /* Terminal Art style */
+    text-shadow: 1px 1px 0px #00FF00,
+                 -1px -1px 0px #00FF00,
+                 1px -1px 0px #00FF00,
+                 -1px 1px 0px #00FF00,
+                 0px 2px 0px #00FF00,
+                 0px -2px 0px #00FF00,
+                 2px 0px 0px #00FF00,
+                 -2px 0px 0px #00FF00;
+    letter-spacing: 2px;
+    /* font-size and margin-bottom are inherited from main section > h1 */
+}
+
 main section article h4 {
     font-size: 1.2em;
     margin-bottom: 0.75em;


### PR DESCRIPTION
I've redesigned the 'Past', 'Present', and 'Future' section titles (`<h1>`) to have a Terminal Art appearance.

This was achieved by:
- Applying multiple `text-shadow` properties to create a blocky, pixelated effect using the existing green color scheme.
- Increasing `letter-spacing` to enhance the retro terminal feel.

The changes are scoped to the specific `<h1>` elements within the `#past`, `#present`, and `#future` sections in `styles.css`, ensuring other elements are not affected.