### PR TITLE
Redesign section titles with ASCII art

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,13 @@
     <main>
       <section id=past>
           <article>
-              <h1>Past</h1>
+              <pre>
+ _____ ____  ____ _____
+|  _  | __ \| __ \_   _|
+| | | |    /|    / | |
+| |_| | |\ \| |\ \ | |
+|_____|_| \_|_| \_\|_|
+              </pre>
                 <h4>- Trainings</h4>
                   <p>. Software Engineering </p>
                   <p>. Platzi Software Development </p>
@@ -38,7 +44,14 @@
       </section>
       <section id=present>
           <article>
-              <h1>Present</h1>
+              <pre>
+ _____ ____  _____ ____  _____ ____ _____
+|  _  | __ \| ____| __ \| ____| __ \_   _|
+| | | |    /| |__ |    /| |__ |    / | |
+| | | | |\ \| __ || |\ \| __ || |\ \ | |
+| |_| | | \ \| |___| | \ \| |___| | \ \ | |
+|_____|_|  \_\|_____|_|  \_\|_____|_|  \_\|_|
+              </pre>
                 <h4>- Trainings</h4>
                   <p>. Master Programming and Software Design</p>
                   <p>. Master Software Development</p>
@@ -49,7 +62,13 @@
       </section>
       <section id=future>
           <article>
-              <h1>Future</h1>
+              <pre>
+ _____ _   _ ____  _   _ ____  _____
+|  ___| | | | __ \| | | | __ \| ____|
+|___  | | | |    /| | | |    /| |__
+ __| | |_| | |\ \| |_| | |\ \| __|
+|_____|\___/|_| \_\|\___/|_| \_\|_|
+              </pre>
                 <h4>- Trainings</h4>
                   <p>. Berlizt English C1</p>
           </article>

--- a/styles.css
+++ b/styles.css
@@ -93,10 +93,19 @@ main article {
     margin-bottom: 1em;
 }
 
-main section > h1 {
+/* main section > h1 {
     font-size: 1.5em;
     margin-bottom: 0.75em;
     /* Color inherited */
+/* } */
+
+main section article pre {
+    font-family: 'Source Code Pro', monospace;
+    color: #00FF00; /* lime green */
+    text-align: center;
+    font-size: 0.6em;
+    line-height: 1.2;
+    margin-bottom: 1em;
 }
 
 main section article h4 {


### PR DESCRIPTION
I replaced the 'Past', 'Present', and 'Future' text titles in their respective sections with ASCII art representations.

- I modified `index.html` to embed the ASCII art using `<pre>` tags.
- I updated `styles.css` to style the ASCII art with a terminal-like appearance (monospace font, green color, centered alignment) and adjusted font size for better visual integration.
- I ensured that the changes maintain the overall page structure and terminal aesthetic.