### PR TITLE
feat: Open social media links in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,10 +83,10 @@
     </main>
     <aside>
         <address>
-            <a href="https://linkedin.com/in/juliocebrito">Linkedin</a>
-            <a href="https://github.com/juliocebrito">Github</a>
-            <a href="https://x.com/juliocebrito">X</a>
-            <a href="https://www.youtube.com/@juliocebrito">YouTube</a>
+            <a href="https://linkedin.com/in/juliocebrito" target="_blank">Linkedin</a>
+            <a href="https://github.com/juliocebrito" target="_blank">Github</a>
+            <a href="https://x.com/juliocebrito" target="_blank">X</a>
+            <a href="https://www.youtube.com/@juliocebrito" target="_blank">YouTube</a>
         </address>
     </aside>
     <footer>


### PR DESCRIPTION
Modified index.html to add the `target="_blank"` attribute to all social media links within the <aside> section. This ensures that when you click on a social media link (LinkedIn, Github, X, YouTube), it opens in a new browser tab or window instead of navigating away from the current page.