### PR TITLE
Fix typo for Berlitz training entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                   <p>. Master Software Development</p>
                   <p>. Desarrollo de aplicaciones tutorizadas </p>
                   <p>. Leadership Academy 2023</p>
-                  <p>. Berlizt English B2</p>
+                  <p>. Berlitz English B2</p>
           </article>
       </section>
       <section id=future>
@@ -73,7 +73,7 @@
                                 
               </pre>
                 <h4>- Trainings</h4>
-                  <p>. Berlizt English C1</p>
+                  <p>. Berlitz English C1</p>
           </article>
       </section>
       <section id=blog>


### PR DESCRIPTION
## Summary
- corrects "Berlizt" to "Berlitz" in training list

## Testing
- `grep -n "Berlitz" index.html`


------
https://chatgpt.com/codex/tasks/task_e_684772496d40832e9678311ae69a9fbc