### PR TITLE
Remove redundant font import

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-@import url(//fonts.googleapis.com/css?family=Source+Code+Pro:200);
 
 /* Global box-sizing */
 *, *::before, *::after {


### PR DESCRIPTION
## Summary
- remove `@import` of Source Code Pro from CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684773470094832e98936d6d34965c43